### PR TITLE
Initial implementation of EKS + Karpenter infrastructure with ARM/x86 workloads support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,37 +1,45 @@
-# Local .terraform directories
+# Ignore Terraform working directory
 .terraform/
 
-# .tfstate files
+# Ignore Terraform state files
 *.tfstate
 *.tfstate.*
 
-# Crash log files
+# Ignore Terraform plan output files
+*.tfplan
+
+# Ignore crash logs
 crash.log
 crash.*.log
 
-# Exclude all .tfvars files, which are likely to contain sensitive data, such as
-# password, private keys, and other secrets. These should not be part of version 
-# control as they are data points which are potentially sensitive and subject 
-# to change depending on the environment.
+# Ignore variable definition files that may contain sensitive data
 *.tfvars
 *.tfvars.json
 
-# Ignore override files as they are usually used to override resources locally and so
-# are not checked in
+# Ignore override files used for local testing and overrides
 override.tf
 override.tf.json
 *_override.tf
 *_override.tf.json
 
-# Ignore transient lock info files created by terraform apply
+# Ignore Terraform state lock file
 .terraform.tfstate.lock.info
 
-# Include override files you do wish to add to version control using negated pattern
-# !example_override.tf
+# Ignore Terraform provider lock file
+.terraform.lock.hcl
 
-# Include tfplan files to ignore the plan output of command: terraform plan -out=tfplan
-# example: *tfplan*
-
-# Ignore CLI configuration files
+# Ignore Terraform CLI configuration files
 .terraformrc
 terraform.rc
+
+# Ignore temporary or backup files from text editors
+*~
+*.swp
+*.log
+
+# Ignore IDE settings (optional)
+.vscode/
+.idea/
+
+# Ignore generic output files (optional)
+output.json

--- a/README.md
+++ b/README.md
@@ -1,0 +1,281 @@
+# 🚀 EKS + Karpenter: Spot & Graviton Autoscaling (Terraform)
+
+This project automates the provisioning of a Kubernetes infrastructure on AWS using:
+
+- **Amazon EKS** (latest version supported)
+- **Karpenter** for dynamic autoscaling
+- **Graviton (arm64)** and **x86 (amd64)** instance support
+- **Spot instances** for optimized cost
+- **Terraform** as the Infrastructure as Code tool
+
+## 📁 Project Structure
+
+- `main.tf` – Root Terraform configuration.
+- `variables.tf` – Input variable definitions.
+- `outputs.tf` – Output values from the deployment.
+- `provider.tf` – AWS, Helm, Kubernetes, and Kubectl providers.
+- `data.tf` – Data sources like EKS auth, ECR token, account identity.
+- `environments/dev.tfvars` – Development environment configuration.
+- `manifests/deployments/` – Example workloads:
+  - `busybox-arm64.yaml`
+  - `busybox-x86.yaml`
+- `manifests/karpenter/` – Karpenter resource definitions:
+  - `ec2-nodeclass.yaml` (x86)
+  - `ec2-nodeclass-arm64.yaml`
+  - `nodepool-x86.yaml`
+  - `nodepool-arm64.yaml`
+- `README.md` – Project documentation.
+
+## 🧩 Features
+
+- Dedicated **VPC** across 3 Availability Zones
+- **EKS 1.33** with managed node group for bootstrapping
+- **Karpenter** deployed via Helm with OIDC IAM integration
+- **Two NodePools**:
+  - `spot-arm64` → Graviton-based nodes
+  - `spot-x86` → AL2023-only nodes
+- Workload examples targeting each architecture
+- Terraform environment separation (e.g. `dev.tfvars`)
+
+## ⚙️ Requirements
+
+- Terraform >= 1.5
+- AWS credentials configured (via `aws configure` or environment variables)
+- `kubectl`, `helm`, and AWS CLI installed
+- `KUBECONFIG` is handled automatically by Terraform providers
+
+## 🚀 Usage
+
+Follow these steps to deploy the infrastructure using Terraform.
+
+---
+
+### 1. Initialize Terraform
+
+Initialize the working directory and download the required providers and modules:
+
+``` bash
+
+terraform init
+
+```
+
+---
+
+### 2. Configure Your Environment
+
+This project uses `.tfvars` files to define the environment configuration.  
+By default, you'll find a sample file at:
+
+environments/dev.tfvars
+
+You can edit it to adjust:
+
+- Cluster name and version
+- VPC CIDR and subnets
+- Availability Zones
+- Managed node groups
+- Access entries, etc.
+
+---
+
+### 3. Apply Terraform
+
+To deploy the infrastructure using the `dev` configuration:
+
+``` bash
+terraform apply -var-file="environments/dev.tfvars"
+
+```
+
+Terraform will provision:
+
+- VPC
+- EKS cluster
+- IAM roles
+- Karpenter via Helm
+- NodeClasses and NodePools
+
+---
+
+### 4. Optional: Manage Multiple Environments
+
+You can create new environment files like:
+
+environments/staging.tfvars  
+environments/prod.tfvars
+
+And combine them with Terraform workspaces for better separation:
+
+``` bash
+
+terraform workspace new staging  
+terraform workspace select staging  
+terraform apply -var-file="environments/staging.tfvars"
+
+```
+
+This keeps the infrastructure state isolated between environments like `dev`, `staging`, and `prod`.
+
+
+### 5. ✅ Validate the Deployment
+
+After Terraform finishes, verify that the infrastructure is working:
+
+---
+
+1.**Configure `kubectl` to connect to the EKS cluster**
+
+Run the following command (replace with your region and cluster name):
+
+``` bash
+
+aws eks update-kubeconfig --region us-east-1 --name eks-karpenter-demo
+
+```
+
+---
+
+2.**Check that the cluster is up**
+
+``` bash
+
+kubectl get nodes  
+kubectl get pods -A
+
+```
+
+---
+
+3.**Verify Karpenter is installed**
+
+``` bash
+kubectl get pods -n karpenter  
+kubectl get deployments -n karpenter
+
+```
+
+## 👨‍💻 Developer Guide: Deploying to x86 or ARM (Graviton) Nodes
+
+Once the infrastructure is ready, as a developer you can deploy your applications to the Kubernetes cluster using standard Kubernetes YAML manifests.
+
+If your application needs to run on a specific processor architecture—like **x86** or **Graviton (ARM64)**—you must include a few lines in your YAML file to tell the cluster **what kind of machine it should run on**.
+
+This guide will show you **how to do that** using real examples.
+
+---
+
+### 🧲 Example: Deploying a Sample App on ARM64 (Graviton)
+
+If you want your app to run on a Graviton-based Spot instance, you can use a sample like this:
+
+File: `manifests/deployments/busybox-arm64.yaml`
+
+This deployment uses:
+
+- **An ARM-compatible container image**: `arm64v8/busybox`
+- A `nodeSelector` to target ARM nodes
+
+To deploy it:
+
+kubectl apply -f manifests/deployments/busybox-arm64.yaml
+
+---
+
+### 🧲 Example: Deploying a Sample App on x86
+
+If you want your app to run on traditional x86 machines:
+
+File: `manifests/deployments/busybox-x86.yaml`
+
+This deployment uses:
+
+- A standard `busybox` image (x86)
+- A `nodeSelector` to ensure it runs only on x86 machines
+
+To deploy:
+
+kubectl apply -f manifests/deployments/busybox-x86.yaml
+
+---
+
+### 🛠 How to Control Where Your Pod Runs
+
+Kubernetes schedules your application ("pod") on a worker node in the cluster.  
+To control **which kind of node** it runs on (x86 vs ARM), you need to **edit the YAML file** of your deployment and add **node selection rules** under the `spec:` section.
+
+There are several ways to do this:
+
+---
+
+#### ✅ 1. nodeSelector (Simple and Recommended)
+
+This is the easiest way to say “run this app only on ARM or x86”.
+
+To run on ARM:
+
+nodeSelector:  
+    kubernetes.io/arch: arm64
+
+To run on x86:
+
+nodeSelector:  
+    kubernetes.io/arch: amd64
+
+Add this inside the `spec.template.spec` block in your `Deployment` YAML.
+
+---
+
+#### 🎯 2. nodeAffinity (Advanced Matching)
+
+Use this if you need **more advanced logic** (e.g., multiple instance types or Spot-only).
+
+Example:
+
+affinity:  
+    nodeAffinity:  
+        requiredDuringSchedulingIgnoredDuringExecution:  
+            nodeSelectorTerms:  
+                - matchExpressions:  
+                    - key: karpenter.k8s.aws/instance-category  
+                      operator: In  
+                      values: ["t", "c", "m"]
+
+---
+
+#### 🛡 3. tolerations (for nodes with taints)
+
+This is used when a node is "tainted" and will **only accept pods** with a matching `toleration`.
+
+tolerations:  
+    - key: "dedicated"  
+      operator: "Equal"  
+      value: "arm64"  
+      effect: "NoSchedule"
+
+> 💡 This must match taints that are defined in the cluster when Karpenter creates certain node groups.
+
+---
+
+### 🔍 How to Check Where Your Pod Landed
+
+After deploying your app, you can see on which node it’s running:
+
+kubectl get pods -n apps -o wide
+
+To get detailed information about the node:
+
+kubectl describe node <node-name>
+
+Look for:
+
+- The architecture (`amd64` or `arm64`)  
+- Instance type and capacity type (Spot, etc.)  
+- Any labels that were used to schedule the pod
+
+---
+
+### 📚 Want to Learn More?
+
+Kubernetes Docs — Assigning Pods to Nodes:  
+<https://kubernetes.io/docs/concepts/scheduling-eviction/assign-pod-node/>

--- a/data.tf
+++ b/data.tf
@@ -1,0 +1,8 @@
+data "aws_eks_cluster_auth" "cluster" {
+  name = module.eks.cluster_name
+}
+
+# Retrieve ECR Public authorization token for Helm chart pull
+data "aws_ecrpublic_authorization_token" "token" {}
+
+data "aws_caller_identity" "current" {}

--- a/eks.tf
+++ b/eks.tf
@@ -1,0 +1,36 @@
+module "eks" {
+  source  = "terraform-aws-modules/eks/aws"
+  version = "~> 20.0"
+
+  cluster_name    = var.cluster_name
+  cluster_version = var.cluster_version
+
+  vpc_id     = module.vpc.vpc_id
+  subnet_ids = module.vpc.private_subnets
+
+  cluster_addons = {
+    coredns                = {}
+    kube-proxy             = {}
+    vpc-cni                = {}
+    aws-ebs-csi-driver     = {}
+    eks-pod-identity-agent = {}
+  }
+
+  cluster_endpoint_public_access       = var.cluster_endpoint_public_access
+  cluster_endpoint_private_access      = var.cluster_endpoint_private_access
+  cluster_endpoint_public_access_cidrs = [var.allowed_cidr]
+
+  # Access control
+  access_entries                           = var.access_entries
+  enable_cluster_creator_admin_permissions = var.enable_cluster_creator_admin_permissions
+
+  eks_managed_node_groups = var.eks_managed_node_groups
+
+  node_security_group_tags = {
+    "karpenter.sh/discovery" = var.cluster_name
+  }
+
+  tags = {
+    "Name" = var.cluster_name
+  }
+}

--- a/environment/dev.tfvars
+++ b/environment/dev.tfvars
@@ -1,0 +1,72 @@
+###############################
+# EKS Cluster Configuration
+###############################
+
+cluster_name                   = "eks-karpenter-demo"
+cluster_version                = "1.33"
+cluster_endpoint_public_access = true
+allowed_cidr                   = ""
+
+###############################
+# Access Control
+###############################
+
+access_entries = {}
+
+enable_cluster_creator_admin_permissions = true
+
+###############################
+# VPC & Subnet Configuration
+###############################
+
+vpc_cidr = "10.0.0.0/16"
+
+azs = [
+  "us-east-1a",
+  "us-east-1b",
+  "us-east-1c"
+]
+
+private_subnets = [
+  "10.0.0.0/22",
+  "10.0.4.0/22",
+  "10.0.8.0/22"
+]
+
+public_subnets = [
+  "10.0.100.0/22",
+  "10.0.104.0/22",
+  "10.0.108.0/22"
+]
+
+###############################
+# NAT Gateway Configuration
+###############################
+
+enable_nat_gateway = true
+single_nat_gateway = true
+
+###############################
+# EKS Managed Node Groups
+###############################
+
+eks_managed_node_groups = {
+  bootstrap = {
+    # ami_type can be set explicitly if needed
+    # ami_type       = "AL2_x86_64"
+    instance_types = ["t3.small"]
+
+    desired_size = 2
+    min_size     = 1
+    max_size     = 2
+
+    labels = {
+      "karpenter.sh/discovery" = "eks-karpenter-demo"
+      "dedicated"              = "karpenter"
+    }
+
+    tags = {
+      "karpenter.sh/discovery" = "eks-karpenter-demo"
+    }
+  }
+}

--- a/iam.tf
+++ b/iam.tf
@@ -1,0 +1,160 @@
+# IAM trust policy for Karpenter controller (OIDC-based service account)
+data "aws_iam_policy_document" "karpenter_assume_role" {
+  statement {
+    effect = "Allow"
+
+    principals {
+      type        = "Federated"
+      identifiers = [module.eks.oidc_provider_arn]
+    }
+
+    actions = ["sts:AssumeRoleWithWebIdentity"]
+
+    condition {
+      test     = "StringEquals"
+      variable = "${replace(module.eks.cluster_oidc_issuer_url, "https://", "")}:sub"
+      values   = ["system:serviceaccount:karpenter:karpenter"]
+    }
+  }
+}
+
+# Karpenter controller IAM role
+resource "aws_iam_role" "karpenter_controller" {
+  name               = "karpenter-controller-role"
+  assume_role_policy = data.aws_iam_policy_document.karpenter_assume_role.json
+}
+
+# IAM policy for Karpenter controller permissions
+data "aws_iam_policy_document" "karpenter_controller_policy" {
+  statement {
+    sid    = "AllowScopedEC2InstanceActions"
+    effect = "Allow"
+    actions = [
+      "ec2:CreateLaunchTemplate",
+      "ec2:CreateFleet",
+      "ec2:RunInstances",
+      "ec2:CreateTags",
+      "ec2:DescribeAvailabilityZones",
+      "ec2:DescribeImages",
+      "ec2:DescribeInstances",
+      "ec2:DescribeInstanceTypes",
+      "ec2:DescribeLaunchTemplates",
+      "ec2:DescribeSecurityGroups",
+      "ec2:DescribeSubnets",
+      "ec2:DescribeVpcs",
+      "ec2:DeleteLaunchTemplate",
+      "ec2:TerminateInstances",
+      "pricing:GetProducts",
+      "ssm:GetParameter",
+      "iam:PassRole",
+      "iam:GetInstanceProfile",
+      "iam:GetRole",
+      "iam:CreateInstanceProfile",
+      "iam:TagInstanceProfile",
+      "iam:AddRoleToInstanceProfile",
+      "iam:RemoveRoleFromInstanceProfile",
+      "iam:DeleteInstanceProfile",
+      "iam:CreateServiceLinkedRole"
+    ]
+    resources = ["*"]
+  }
+
+  statement {
+    sid       = "AllowScopedSSMAndPricing"
+    effect    = "Allow"
+    actions   = ["ssm:GetParameter", "pricing:GetProducts"]
+    resources = ["*"]
+  }
+
+  statement {
+    sid    = "AllowScopedInterruptionActions"
+    effect = "Allow"
+    actions = [
+      "ec2:DescribeSpotPriceHistory",
+      "ec2:DescribeInstanceTypeOfferings"
+    ]
+    resources = ["*"]
+  }
+
+  statement {
+    sid     = "EKSDescribe"
+    effect  = "Allow"
+    actions = ["eks:DescribeCluster", "eks:AccessKubernetesApi"]
+    resources = [
+      "arn:aws:eks:${var.region}:${data.aws_caller_identity.current.account_id}:cluster/${module.eks.cluster_name}"
+    ]
+  }
+}
+
+# Create IAM policy and attach to controller role
+resource "aws_iam_policy" "karpenter_controller" {
+  name   = "karpenter-controller-policy"
+  policy = data.aws_iam_policy_document.karpenter_controller_policy.json
+}
+
+resource "aws_iam_role_policy_attachment" "karpenter_controller_attach" {
+  role       = aws_iam_role.karpenter_controller.name
+  policy_arn = aws_iam_policy.karpenter_controller.arn
+}
+
+# IAM trust policy for Karpenter nodes
+data "aws_iam_policy_document" "karpenter_node_assume_role" {
+  statement {
+    effect = "Allow"
+
+    principals {
+      type        = "Service"
+      identifiers = ["ec2.amazonaws.com"]
+    }
+
+    actions = ["sts:AssumeRole"]
+  }
+}
+
+# IAM role for EC2 instances provisioned by Karpenter
+resource "aws_iam_role" "karpenter_node" {
+  name               = "karpenter-node-role"
+  assume_role_policy = data.aws_iam_policy_document.karpenter_node_assume_role.json
+}
+
+# Attach required managed policies to the Karpenter node role
+resource "aws_iam_role_policy_attachment" "karpenter_node_worker" {
+  role       = aws_iam_role.karpenter_node.name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEKSWorkerNodePolicy"
+}
+
+resource "aws_iam_role_policy_attachment" "karpenter_node_cni" {
+  role       = aws_iam_role.karpenter_node.name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEKS_CNI_Policy"
+}
+
+resource "aws_iam_role_policy_attachment" "karpenter_node_registry" {
+  role       = aws_iam_role.karpenter_node.name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly"
+}
+
+resource "aws_iam_role_policy_attachment" "karpenter_node_ssm" {
+  role       = aws_iam_role.karpenter_node.name
+  policy_arn = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
+}
+
+resource "aws_iam_role_policy_attachment" "karpenter_node_ebs" {
+  role       = aws_iam_role.karpenter_node.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonEBSCSIDriverPolicy"
+}
+
+# Instance profile required for EC2 instances
+resource "aws_iam_instance_profile" "karpenter_node" {
+  name = "karpenter-node-instance-profile"
+  role = aws_iam_role.karpenter_node.name
+}
+
+# EKS Access entry for Karpenter nodes (new EKS access management)
+resource "aws_eks_access_entry" "node" {
+  cluster_name  = var.cluster_name
+  principal_arn = aws_iam_role.karpenter_node.arn
+  type          = "EC2_LINUX"
+  tags          = {}
+
+  depends_on = [module.eks, aws_iam_role.karpenter_node]
+}

--- a/karpenter.tf
+++ b/karpenter.tf
@@ -1,0 +1,39 @@
+resource "helm_release" "karpenter" {
+  name             = "karpenter"
+  namespace        = "karpenter"
+  create_namespace = true
+
+  repository          = "oci://public.ecr.aws/karpenter"
+  repository_username = data.aws_ecrpublic_authorization_token.token.user_name
+  repository_password = data.aws_ecrpublic_authorization_token.token.password
+  chart               = "karpenter"
+  version             = "1.5.2"
+
+  set = [
+    {
+      name  = "settings.clusterName"
+      value = module.eks.cluster_name
+    },
+    {
+      name  = "settings.clusterEndpoint"
+      value = module.eks.cluster_endpoint
+    },
+    {
+      name  = "settings.defaultInstanceProfile"
+      value = aws_iam_instance_profile.karpenter_node.name
+    },
+    {
+      name  = "serviceAccount.annotations.eks\\.amazonaws\\.com/role-arn"
+      value = aws_iam_role.karpenter_controller.arn
+    },
+    {
+      name  = "nodeSelector.dedicated"
+      value = "karpenter"
+    }
+  ]
+
+  depends_on = [
+    aws_iam_role.karpenter_controller,
+    data.aws_ecrpublic_authorization_token.token
+  ]
+}

--- a/kp_nodepool.tf
+++ b/kp_nodepool.tf
@@ -1,0 +1,23 @@
+# EC2NodeClass for x86_64 instances
+resource "kubectl_manifest" "nodeclass_x86" {
+  yaml_body  = file("${path.module}/manifests/karpenter/ec2-nodeclass-x86.yaml")
+  depends_on = [helm_release.karpenter]
+}
+
+# NodePool for x86_64 spot instances
+resource "kubectl_manifest" "nodepool_spot_x86" {
+  yaml_body  = file("${path.module}/manifests/karpenter/nodepool-x86.yaml")
+  depends_on = [kubectl_manifest.nodeclass_x86]
+}
+
+# EC2NodeClass for ARM64 instances
+resource "kubectl_manifest" "nodeclass_arm64" {
+  yaml_body  = file("${path.module}/manifests/karpenter/ec2-nodeclass-arm64.yaml")
+  depends_on = [helm_release.karpenter]
+}
+
+# NodePool for ARM64 spot instances
+resource "kubectl_manifest" "nodepool_spot_arm64" {
+  yaml_body  = file("${path.module}/manifests/karpenter/nodepool-arm64.yaml")
+  depends_on = [kubectl_manifest.nodeclass_arm64]
+}

--- a/manifests/deployments/busybox-arm64.yaml
+++ b/manifests/deployments/busybox-arm64.yaml
@@ -1,0 +1,28 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: busybox-arm64
+  namespace: apps
+spec:
+  replicas: 5
+  selector:
+    matchLabels:
+      app: busybox-arm64
+  template:
+    metadata:
+      labels:
+        app: busybox-arm64
+    spec:
+      nodeSelector:
+        kubernetes.io/arch: arm64
+      containers:
+        - name: busybox
+          image: arm64v8/busybox
+          args: ["sleep", "3600"]
+          resources:
+            requests:
+              cpu: "100m"
+              memory: "50Mi"
+            limits: # <-- Aquí es donde agregamos los límites
+              cpu: "200m"
+              memory: "100Mi"

--- a/manifests/deployments/busybox-x86.yaml
+++ b/manifests/deployments/busybox-x86.yaml
@@ -1,0 +1,28 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: busybox-x86
+  namespace: apps
+spec:
+  replicas: 8
+  selector:
+    matchLabels:
+      app: busybox-x86
+  template:
+    metadata:
+      labels:
+        app: busybox-x86
+    spec:
+      nodeSelector:
+        kubernetes.io/arch: amd64
+      containers:
+        - name: busybox
+          image: busybox
+          args: ["sleep", "3600"]
+          resources:
+            requests:
+              cpu:  "100m"
+              memory: "50Mi"
+            limits:
+              cpu: "200m"
+              memory: "100Mi"

--- a/manifests/deployments/inflate-arm64.yaml
+++ b/manifests/deployments/inflate-arm64.yaml
@@ -1,0 +1,26 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: inflate
+  namespace: apps
+spec:
+  replicas: 2
+  selector:
+    matchLabels:
+      app: inflate
+  template:
+    metadata:
+      labels:
+        app: inflate
+    spec:
+      terminationGracePeriodSeconds: 0
+      containers:
+        - name: inflate
+          image: public.ecr.aws/eks-distro/kubernetes/pause:3.7
+          resources:
+            requests:
+              cpu: "1"
+              memory: "50Mi"
+            limits:
+              cpu: "1"
+              memory: "100Mi"

--- a/manifests/deployments/nginx-x86.yaml
+++ b/manifests/deployments/nginx-x86.yaml
@@ -1,0 +1,28 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: nginx
+  namespace: apps
+spec:
+  replicas: 4
+  selector:
+    matchLabels:
+      app: nginx
+  template:
+    metadata:
+      labels:
+        app: nginx
+    spec:
+      nodeSelector:
+        kubernetes.io/arch: amd64
+      terminationGracePeriodSeconds: 0
+      containers:
+        - name: nginx
+          image: nginx
+          resources:
+            requests:
+              cpu:  "500m"
+              memory: "50Mi"
+            limits:
+              cpu: "900m"
+              memory: "100Mi"

--- a/manifests/karpenter/ec2-nodeclass-arm64.yaml
+++ b/manifests/karpenter/ec2-nodeclass-arm64.yaml
@@ -1,0 +1,14 @@
+apiVersion: karpenter.k8s.aws/v1
+kind: EC2NodeClass
+metadata:
+  name: default-spot-arm64
+spec:                  
+  amiSelectorTerms:                           
+    - alias: bottlerocket@latest 
+  role: karpenter-node-role
+  subnetSelectorTerms:
+    - tags:
+        karpenter.sh/discovery: "eks-karpenter-demo"
+  securityGroupSelectorTerms:
+    - tags:
+        karpenter.sh/discovery: "eks-karpenter-demo"

--- a/manifests/karpenter/ec2-nodeclass-x86.yaml
+++ b/manifests/karpenter/ec2-nodeclass-x86.yaml
@@ -1,0 +1,14 @@
+apiVersion: karpenter.k8s.aws/v1
+kind: EC2NodeClass
+metadata:
+  name: default-spot-x86
+spec:
+  amiSelectorTerms:
+    - alias: al2023@v20250627
+  role: karpenter-node-role
+  subnetSelectorTerms:
+    - tags:
+        karpenter.sh/discovery: "eks-karpenter-demo"
+  securityGroupSelectorTerms:
+    - tags:
+        karpenter.sh/discovery: "eks-karpenter-demo"

--- a/manifests/karpenter/nodepool-arm64.yaml
+++ b/manifests/karpenter/nodepool-arm64.yaml
@@ -1,0 +1,31 @@
+apiVersion: karpenter.sh/v1
+kind: NodePool
+metadata:
+  name: spot-arm64
+spec:
+  template:
+    spec:
+      expireAfter: 5m
+      nodeClassRef:
+        group: karpenter.k8s.aws
+        kind: EC2NodeClass
+        name: default-spot-arm64
+      requirements:
+        - key: karpenter.sh/capacity-type
+          operator: In
+          values: ["spot"]
+        - key: kubernetes.io/arch
+          operator: In
+          values: ["arm64"]
+        - key: karpenter.k8s.aws/instance-category
+          operator: In
+          values: ["t", "m", "c"]       
+        - key: karpenter.k8s.aws/instance-generation
+          operator: Gt
+          values: ["5"]   
+  limits:
+    cpu: "10"
+  disruption:
+    consolidationPolicy: WhenEmpty
+    consolidateAfter: 30s
+    expireAfter: 10s

--- a/manifests/karpenter/nodepool-x86.yaml
+++ b/manifests/karpenter/nodepool-x86.yaml
@@ -1,0 +1,33 @@
+apiVersion: karpenter.sh/v1
+kind: NodePool
+metadata:
+  name: spot-x86
+spec:
+  template:
+    spec:
+      nodeClassRef:
+        group: karpenter.k8s.aws
+        kind: EC2NodeClass
+        name: default-spot-x86
+      requirements:
+        - key: karpenter.sh/capacity-type
+          operator: In
+          values: ["spot"]
+        - key: kubernetes.io/arch
+          operator: In
+          values: ["amd64"]
+        - key: "karpenter.k8s.aws/instance-hypervisor"
+          operator: In
+          values: ["nitro"]
+        - key: "karpenter.k8s.aws/instance-category"
+          operator: In
+          values: ["t", "m", "c"]
+        - key: "karpenter.k8s.aws/instance-generation"
+          operator: Gt
+          values: ["2"]
+  limits:
+    cpu: "10"
+  disruption:
+    consolidationPolicy: WhenEmptyOrUnderutilized
+    consolidateAfter: 30s
+    expireAfter: 1m

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,0 +1,42 @@
+# VPC outputs
+output "vpc_id" {
+  value = module.vpc.vpc_id
+}
+
+output "private_subnets" {
+  value = module.vpc.private_subnets
+}
+
+output "public_subnets" {
+  value = module.vpc.public_subnets
+}
+
+# EKS cluster outputs
+output "cluster_name" {
+  value = module.eks.cluster_name
+}
+
+output "cluster_endpoint" {
+  value = module.eks.cluster_endpoint
+}
+
+output "cluster_ca_certificate" {
+  value = module.eks.cluster_certificate_authority_data
+}
+
+output "oidc_provider_arn" {
+  value = module.eks.oidc_provider_arn
+}
+
+# Karpenter IAM and instance profile outputs
+output "karpenter_controller_role_arn" {
+  value = aws_iam_role.karpenter_controller.arn
+}
+
+output "karpenter_node_instance_profile" {
+  value = aws_iam_instance_profile.karpenter_node.arn
+}
+
+output "karpenter_node_role_name" {
+  value = aws_iam_role.karpenter_node.name
+}

--- a/provider.tf
+++ b/provider.tf
@@ -1,0 +1,23 @@
+provider "aws" {
+  region = var.region
+}
+
+provider "helm" {
+  kubernetes = {
+    host                   = module.eks.cluster_endpoint
+    cluster_ca_certificate = base64decode(module.eks.cluster_certificate_authority_data)
+    token                  = data.aws_eks_cluster_auth.cluster.token
+  }
+}
+
+provider "kubernetes" {
+  host                   = module.eks.cluster_endpoint
+  cluster_ca_certificate = base64decode(module.eks.cluster_certificate_authority_data)
+  token                  = data.aws_eks_cluster_auth.cluster.token
+}
+
+provider "kubectl" {
+  host                   = module.eks.cluster_endpoint
+  cluster_ca_certificate = base64decode(module.eks.cluster_certificate_authority_data)
+  token                  = data.aws_eks_cluster_auth.cluster.token
+}

--- a/variable.tf
+++ b/variable.tf
@@ -1,0 +1,107 @@
+###########################################
+# General Configuration
+###########################################
+
+variable "region" {
+  description = "The AWS region"
+  type        = string
+  default     = "us-east-1"
+}
+
+variable "cluster_name" {
+  description = "EKS cluster name"
+  type        = string
+}
+
+variable "cluster_version" {
+  description = "EKS Kubernetes version"
+  type        = string
+  default     = "1.33"
+}
+
+###########################################
+# VPC & Subnet Configuration
+###########################################
+
+variable "vpc_cidr" {
+  description = "CIDR block for the VPC"
+  type        = string
+}
+
+variable "azs" {
+  description = "List of Availability Zones"
+  type        = list(string)
+}
+
+variable "private_subnets" {
+  description = "List of private subnet CIDRs"
+  type        = list(string)
+}
+
+variable "public_subnets" {
+  description = "List of public subnet CIDRs"
+  type        = list(string)
+}
+
+###########################################
+# NAT Gateway Configuration
+###########################################
+
+variable "enable_nat_gateway" {
+  description = "Determines whether to create a NAT Gateway for private subnets"
+  type        = bool
+  default     = false
+}
+
+variable "single_nat_gateway" {
+  description = "Determines whether to use a single NAT Gateway (true) or one per AZ (false)"
+  type        = bool
+  default     = false
+}
+
+###########################################
+# EKS Access Control
+###########################################
+
+variable "allowed_cidr" {
+  description = "CIDR from which the EKS public endpoint can be accessed"
+  type        = string
+}
+
+variable "access_entries" {
+  description = "Map of access entries to add to the cluster"
+  type        = any
+  default     = {}
+}
+
+variable "enable_cluster_creator_admin_permissions" {
+  description = "Whether to grant cluster admin access to the Terraform identity"
+  type        = bool
+  default     = false
+}
+
+###########################################
+# EKS Endpoint Access
+###########################################
+
+variable "cluster_endpoint_public_access" {
+  description = "Enable the Amazon EKS public API server endpoint"
+  type        = bool
+  default     = false
+}
+
+variable "cluster_endpoint_private_access" {
+  description = "Enable the Amazon EKS private API server endpoint"
+  type        = bool
+  default     = true
+}
+
+###########################################
+# EKS Node Groups
+###########################################
+
+variable "eks_managed_node_groups" {
+  description = "Map of EKS managed node groups to create (empty map = none)"
+  type        = any
+  default     = {}
+}

--- a/version.tf
+++ b/version.tf
@@ -1,0 +1,25 @@
+terraform {
+  required_version = ">= 1.5.0"
+
+  required_providers {
+    aws = {
+      source  = "hashicorp/aws"
+      version = "~> 5.0"
+    }
+
+    helm = {
+      source  = "hashicorp/helm"
+      version = ">= 2.9.0"
+    }
+
+    kubernetes = {
+      source  = "hashicorp/kubernetes"
+      version = ">= 2.23.0"
+    }
+
+    kubectl = {
+      source  = "gavinbunney/kubectl"
+      version = ">= 1.14.0"
+    }
+  }
+}

--- a/vpc.tf
+++ b/vpc.tf
@@ -1,0 +1,30 @@
+module "vpc" {
+  source  = "terraform-aws-modules/vpc/aws"
+  version = "~> 5.0"
+
+  name = "${var.cluster_name}-vpc"
+  cidr = var.vpc_cidr
+
+  azs             = var.azs
+  private_subnets = var.private_subnets
+  public_subnets  = var.public_subnets
+
+  enable_nat_gateway = var.enable_nat_gateway
+  single_nat_gateway = var.single_nat_gateway
+
+  # Tags for private subnets (used by EKS and Karpenter)
+  private_subnet_tags = {
+    "kubernetes.io/cluster/${var.cluster_name}" = "shared"
+    "kubernetes.io/role/internal-elb"           = 1
+    "karpenter.sh/discovery"                    = "eks-karpenter-demo"
+  }
+
+  # Tags for public subnets (optional, currently empty)
+  public_subnet_tags = {
+    # Add public subnet tags if needed (e.g. for external ELB)
+  }
+
+  tags = {
+    "Name" = "${var.cluster_name}-vpc"
+  }
+}


### PR DESCRIPTION
## Main Changes 
- Full implementation of EKS infrastructure on AWS using Terraform
- Karpenter setup as autoscaler with support for both ARM64 (Graviton) and x86 nodes
- NodePools and EC2NodeClasses for Spot instances
- IAM roles and policies defined for Karpenter controller and worker nodes
- VPC module with private and public subnets
- Test workloads defined in Kubernetes manifests for both architectures
- Detailed README with developer instructions for usage and deployment
